### PR TITLE
Replace deprecated API for failover_urls

### DIFF
--- a/Dockerfile.centos7_upstream
+++ b/Dockerfile.centos7_upstream
@@ -1,4 +1,4 @@
-FROM library/centos:7
+FROM quay.io/centos/centos:7
 # Fedora 31 and Centos 7 (epel 7) are latest versions that ship qpid-cpp
 
 RUN yum install -y dnf \
@@ -21,6 +21,7 @@ RUN yum install -y dnf \
     \
     cyrus-sasl-devel \
     openssl-devel \
+    python3-devel \
     \
 && yum clean all \
 && dnf clean all \

--- a/src/api/qpid-proton/reactor/handler/CommonHandler.cpp
+++ b/src/api/qpid-proton/reactor/handler/CommonHandler.cpp
@@ -87,8 +87,6 @@ CommonHandler::~CommonHandler()
 void CommonHandler::configure_reconnect(::proton::connection_options & conn_opts) {
     ::proton::reconnect_options ro;
 
-    ro.failover_urls(conn_urls);
-
     if (conn_reconnect == "true" && conn_reconnect_custom == false) {
         conn_opts.reconnect(ro);
     } else if (conn_reconnect == "true" && conn_reconnect_custom == true) {

--- a/src/api/qpid-proton/reactor/handler/ConnectorHandler.cpp
+++ b/src/api/qpid-proton/reactor/handler/ConnectorHandler.cpp
@@ -124,6 +124,7 @@ void ConnectorHandler::on_container_start(container &c)
         conn_opts.sasl_allow_insecure_mechs(true);
         conn_opts.sasl_allowed_mechs(sasl_mechanisms);
         conn_opts.max_frame_size(max_frame_size);
+        conn_opts.failover_urls(conn_urls);
 
         logger(debug) << "Setting a reconnect timer: " << conn_reconnect;
         logger(debug) << "Custom reconnect: " << conn_reconnect_custom;

--- a/src/api/qpid-proton/reactor/handler/ReceiverHandler.cpp
+++ b/src/api/qpid-proton/reactor/handler/ReceiverHandler.cpp
@@ -192,6 +192,7 @@ void ReceiverHandler::on_container_start(container &c)
     conn_opts.sasl_allow_insecure_mechs(true);
     conn_opts.sasl_allowed_mechs(sasl_mechanisms);
     // conn_opts.max_frame_size(max_frame_size);
+    conn_opts.failover_urls(conn_urls);
 
     logger(debug) << "Setting a reconnect timer: " << conn_reconnect;
     logger(debug) << "Custom reconnect: " << conn_reconnect_custom;

--- a/src/api/qpid-proton/reactor/handler/SenderHandler.cpp
+++ b/src/api/qpid-proton/reactor/handler/SenderHandler.cpp
@@ -152,6 +152,7 @@ void SenderHandler::on_container_start(container &c)
     conn_opts.sasl_allow_insecure_mechs(true);
     conn_opts.sasl_allowed_mechs(sasl_mechanisms);
     // conn_opts.max_frame_size(max_frame_size);
+    conn_opts.failover_urls(conn_urls);
 
     logger(debug) << "Setting a reconnect timer: " << conn_reconnect;
     logger(debug) << "Custom reconnect: " << conn_reconnect_custom;


### PR DESCRIPTION
```
[13:20:07] [INFO] dtestlib.Test :: stderr:
  /var/dtests/node_data/clients/cli-cpp/src/api/qpid-proton/reactor/handler/CommonHandler.cpp: In member function ‘void dtests::proton::reactor::CommonHandler::configure_reconnect(proton::connection_options&)’:
  /var/dtests/node_data/clients/cli-cpp/src/api/qpid-proton/reactor/handler/CommonHandler.cpp:90:31: warning: ‘proton::reconnect_options& proton::reconnect_options::failover_urls(const std::vector<std::basic_string<char> >&)’ is deprecated (declared at /usr/include/proton/reconnect_options.hpp:82): use connection_options::failover_urls() [-Wdeprecated-declarations]
       ro.failover_urls(conn_urls);
```

Relates:
* PROTON-2040 / ENTMQCL-1577 [cpp] Allow connection options to be updated for automatic reconnect
* ENTMQCL-1683 [dtests][aac3] Replace deprecated failover_urls API