### PR TITLE
Fix failing GitHub Actions Bazel CI

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -107,6 +107,14 @@ filegroup(name = "sources", srcs = glob(["CMakeLists.txt", "src/**", "dist/**", 
 cmake(
    name = "cli-cpp",
    generate_crosstool_file = False,
+
+   # Qpid Cpp has absolute paths in QpidConfig.cmake, can't use that
+   #  Let's disable sandbox instead, and we'd need to fix in Qpid Cpp
+   #env = {
+   #    "LDFLAGS": "-L$$EXT_BUILD_DEPS/qpid-cpp/lib64"
+   #},
+   tags = ["no-sandbox"],
+
    cache_entries = {
        "CMAKE_CXX_COMPILER": "g++",
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -40,6 +40,7 @@ proton_cache_entries = {
 
 cmake(
    name = "qpid-proton",
+   generate_crosstool_file = False,
    cache_entries = select({
        ":ccache_enabled": dicts.add(proton_cache_entries, cmake_compiler_launcher),
        "//conditions:default": proton_cache_entries,
@@ -82,6 +83,7 @@ qpid_cache_entries = {
 
 cmake(
    name = "qpid-cpp",
+   generate_crosstool_file = False,
    cache_entries = select({
        ":ccache_enabled": dicts.add(qpid_cache_entries, cmake_compiler_launcher),
        "//conditions:default": qpid_cache_entries,
@@ -100,6 +102,7 @@ filegroup(name = "sources", srcs = glob(["CMakeLists.txt", "src/**", "dist/**", 
 
 cmake(
    name = "cli-cpp",
+   generate_crosstool_file = False,
    cache_entries = {
        "CMAKE_CXX_COMPILER": "g++",
 
@@ -107,6 +110,8 @@ cmake(
        "Qpid_DIR": "$EXT_BUILD_DEPS/qpid-cpp/lib64/cmake/Qpid",
        "Proton_DIR": "$EXT_BUILD_DEPS/qpid-proton/lib64/cmake/Proton",
        "ProtonCpp_DIR": "$EXT_BUILD_DEPS/qpid-proton/lib64/cmake/ProtonCpp",
+
+       "CMAKE_VERBOSE_MAKEFILE": "ON",
 
        "CMAKE_BUILD_WITH_INSTALL_RPATH": "TRUE",
        "CMAKE_INSTALL_RPATH_USE_LINK_PATH": "TRUE",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -92,6 +92,10 @@ cmake(
 
    build_args = ["-j8"],
 
+   # https://github.com/bazelbuild/rules_foreign_cc/issues/418#issuecomment-790423504
+   # this does not seem to be a problem for me, but it's weird
+   #includes = ["."],
+
    out_lib_dir = "lib64",
    out_shared_libs = ["libqpidclient.so", "libqpidcommon.so", "libqpidtypes.so", "libqpidmessaging.so"],
 
@@ -106,7 +110,10 @@ cmake(
    cache_entries = {
        "CMAKE_CXX_COMPILER": "g++",
 
+       # https://github.com/bazelbuild/rules_foreign_cc/pull/970#issuecomment-1282134709
        "EXT_BUILD_DEPS": "$EXT_BUILD_DEPS",
+       "EXT_BUILD_ROOT": "$EXT_BUILD_ROOT",
+
        "Qpid_DIR": "$EXT_BUILD_DEPS/qpid-cpp/lib64/cmake/Qpid",
        "Proton_DIR": "$EXT_BUILD_DEPS/qpid-proton/lib64/cmake/Proton",
        "ProtonCpp_DIR": "$EXT_BUILD_DEPS/qpid-proton/lib64/cmake/ProtonCpp",

--- a/BUILD.md
+++ b/BUILD.md
@@ -17,7 +17,7 @@ Qpid Cpp
 
 * nss-devel
 * python2
-  * ` python2 -m ensurepip --user --upgrade` to get setuptools for it
+  * `python2 -m ensurepip --user --upgrade` to get setuptools for it
 
 ## Two ways to build
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,5 +1,24 @@
 # Build instructions
 
+## Requirements
+
+This project depends on Qpid Cpp and Qpid Proton messaging libraries.
+These have their own dependencies in turn.
+Here is (possibly incomplete) list for Fedora/RHEL to install.
+(In other words, the build is not hermetic/self-contained, not even with Bazel.)
+
+Cli Cpp
+
+* boost_regex
+
+Proton Cpp
+
+Qpid Cpp
+
+* nss-devel
+* python2
+  * ` python2 -m ensurepip --user --upgrade` to get setuptools for it
+
 ## Two ways to build
 
 This project can be built either with CMake, or with CMake executed by Bazel.

--- a/BUILD.md
+++ b/BUILD.md
@@ -47,6 +47,13 @@ When building with ccache, add the following
 
     --sandbox_writable_path=$HOME/.ccache
 
+#### Troubleshooting
+
+Preserve sandbox with `--sandbox_debug` flag.
+Get more output with `--verbose_failures` flag.
+
+Disable sandbox with `--spawn_strategy=standalone` flag, use values of `processwrapper-sandbox`, `linux-sandbox`, ...
+
 ### CMake build
 
 If you want to use the dependencies built by Bazel in your CMake build, do this.

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -5,32 +5,37 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Group the sources of the library so that CMake rule have access to it
 all_content = """filegroup(name = "all", srcs = glob(["**"]), visibility = ["//visibility:public"])"""
 
-# Rule repository
+# Rule repositories #
+
+# https://github.com/bazelbuild/bazel-skylib
+
 http_archive(
     name = "bazel_skylib",
     urls = [
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
     ],
-    sha256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
+    sha256 = "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
 )
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 bazel_skylib_workspace()
 
+# https://github.com/bazelbuild/rules_foreign_cc
+
 http_archive(
     name = "rules_foreign_cc",
-    sha256 = "69023642d5781c68911beda769f91fcbc8ca48711db935a75da7f6536b65047f",
-    strip_prefix = "rules_foreign_cc-0.6.0",
-    url = "https://github.com/bazelbuild/rules_foreign_cc/archive/0.6.0.tar.gz",
+    sha256 = "2a4d07cd64b0719b39a7c12218a3e507672b82a97b98c6a89d38565894cf7c51",
+    strip_prefix = "rules_foreign_cc-0.9.0",
+    url = "https://github.com/bazelbuild/rules_foreign_cc/archive/refs/tags/0.9.0.tar.gz",
 )
 
 load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 
 # This sets up some common toolchains for building targets. For more details, please see
-# https://bazelbuild.github.io/rules_foreign_cc/0.6.0/flatten.html#rules_foreign_cc_dependencies
+# https://bazelbuild.github.io/rules_foreign_cc/0.9.0/flatten.html#rules_foreign_cc_dependencies
 rules_foreign_cc_dependencies()
 
-# Qpid upstream source code repositories
+# Qpid upstream source code repositories #
 
 http_archive(
    name = "qpid-proton",

--- a/src/api/qpid-proton/CMakeLists.txt
+++ b/src/api/qpid-proton/CMakeLists.txt
@@ -41,7 +41,6 @@ if (WIN32)
     target_link_libraries(
         dtests-proton-common
 
-        qpid-proton
         dtests-cpp-contrib
         dtests-cpp-common
         dtests-cpp-common-options
@@ -50,7 +49,6 @@ else (WIN32)
     target_link_libraries(
         dtests-proton-common
 
-        qpid-proton
         boost_regex
         dtests-cpp-contrib
         dtests-cpp-common

--- a/src/api/qpid/CMakeLists.txt
+++ b/src/api/qpid/CMakeLists.txt
@@ -68,8 +68,7 @@ add_library(
 target_link_libraries(
 	dtests-qpid-messaging-common
 
-	qpidmessaging
-	qpidtypes
+	${Qpid_LIBRARIES}
 	dtests-cpp-legacy
 	boost_regex  # would be `Boost::regex` in new CMake
 	${qpid_client_link_libraries}
@@ -144,7 +143,7 @@ add_library(dtests-cpp-legacy
 )
 
 target_link_libraries(dtests-cpp-legacy
-	qpidmessaging
+	${Qpid_LIBRARIES}
 	dtests-cpp-common
 )
 


### PR DESCRIPTION
The problem is in Qpid Cpp which uses absolute paths in QpidConfig.cmake. My build moves the built artifacts around, and that breaks things.

Workaround is to disable Bazel sandbox in targets that use qpid-cpp.