### PR TITLE
Add proton includes to hopefully fix Win build issue

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -55,6 +55,9 @@ add_library(dtests-cpp-common
     Utils.cpp
 )
 
+target_include_directories(dtests-cpp-common
+    PRIVATE ${PROTON_INCLUDE_DIR}
+)
 if (WIN32)
     target_link_libraries(dtests-cpp-common)
 else (WIN32)


### PR DESCRIPTION
```
[C:\dtests\node_data\clients\cpp\src\aac0_sender.vcxproj]
            C:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\include\stdlib.h(449) : see declaration of 'getenv'
    FormatUtil.cpp
  C:/dtests/node_data/clients/cpp/src/common\formatter/DictFormatter.h(11): fatal error C1083: Cannot open include file: 'proton/message.hpp': No such file or directory [C:\dtests\node_data\clients\cpp\src\aac0_sender.vcxproj]
    Generating Code...
  Done Building Project "C:\dtests\node_data\clients\cpp\src\aac0_sender.vcxproj" (rebuild target(s)) -- FAILED.

  Build FAILED.
```