### PR TITLE
Revert "Link qpid-proton-cpp using the CMake target name"

### DIFF
--- a/src/api/qpid-proton/CMakeLists.txt
+++ b/src/api/qpid-proton/CMakeLists.txt
@@ -77,7 +77,7 @@ target_link_libraries(
     dtests-cpp-common-options
     dtests-proton-common
 
-    Proton::cpp
+    qpid-proton-cpp
 )
 
 set(proton-reactor-clients


### PR DESCRIPTION
This reverts commit cc3940dff02eb658f3e8a9306bdd5ca71d748fd1.