### PR TITLE
Improve conditional inclusion of tracing, also condition on Proton version

### DIFF
--- a/src/api/qpid-proton/CMakeLists.txt
+++ b/src/api/qpid-proton/CMakeLists.txt
@@ -18,7 +18,7 @@ else(${DTEST_BUILD_PLATFORM} EQUAL "64")
     )
 endif(${DTEST_BUILD_PLATFORM} EQUAL "64")
 
-if (UNIX AND PROTON_VERSION VERSION_GREATER_EQUAL 0.38.0)
+if (UNIX AND ProtonCpp_VERSION VERSION_GREATER_EQUAL 0.38.0)
     set(MODERNClient_tracing_src common/ModernClient_tracing_opentracing.cpp)
 else ()
     set(MODERNClient_tracing_src common/ModernClient_tracing_none.cpp)

--- a/src/api/qpid-proton/CMakeLists.txt
+++ b/src/api/qpid-proton/CMakeLists.txt
@@ -18,11 +18,19 @@ else(${DTEST_BUILD_PLATFORM} EQUAL "64")
     )
 endif(${DTEST_BUILD_PLATFORM} EQUAL "64")
 
+if (UNIX AND PROTON_VERSION VERSION_GREATER_EQUAL 0.38.0)
+    set(MODERNClient_tracing_src common/ModernClient_tracing_opentracing.cpp)
+else ()
+    set(MODERNClient_tracing_src common/ModernClient_tracing_none.cpp)
+endif ()
+
+
 cmake_policy(SET CMP0003 OLD)
 add_library(
     dtests-proton-common
     
     common/ModernClient.cpp
+    ${MODERNClient_tracing_src}
 )
 
 if (WIN32)

--- a/src/api/qpid-proton/common/ModernClient.cpp
+++ b/src/api/qpid-proton/common/ModernClient.cpp
@@ -78,39 +78,6 @@ void ModernClient::setLogLevel(const optparse::Values &options) const
 
 }
 
-void ModernClient::enableTracing(std::string service_name) const
-{
-
-#ifdef __unix__
-    opentelemetry::exporter::jaeger::JaegerExporterOptions opts;
-
-    // Initialize Jaeger Exporter
-    std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> exporter = std::unique_ptr<opentelemetry::sdk::trace::SpanExporter>(
-            new opentelemetry::exporter::jaeger::JaegerExporter(opts));
-
-    // Set service-name
-    auto resource_attributes = opentelemetry::sdk::resource::ResourceAttributes
-            {
-                    {"service.name", service_name}
-            };
-
-    // Creation of the resource for associating it with telemetry
-    auto resource = opentelemetry::sdk::resource::Resource::Create(resource_attributes);
-
-    auto processor = std::unique_ptr<opentelemetry::sdk::trace::SpanProcessor>(
-            new opentelemetry::sdk::trace::SimpleSpanProcessor(std::move(exporter)));
-    auto provider = opentelemetry::nostd::shared_ptr<opentelemetry::trace::TracerProvider>(
-            new opentelemetry::sdk::trace::TracerProvider(std::move(processor), resource));
-
-    // Set the global trace provider
-    opentelemetry::trace::Provider::SetTracerProvider(provider);
-
-    // Enable tracing in proton cpp
-    ::proton::initOpenTelemetryTracer();
-#endif
-
-}
-
 
 } /* namespace messenger */
 } /* namespace proton */

--- a/src/api/qpid-proton/common/ModernClient.h
+++ b/src/api/qpid-proton/common/ModernClient.h
@@ -13,22 +13,6 @@
 #include <string>
 #include <memory>
 
-#include <proton/tracing.hpp>
-
-#ifdef __unix__
-#include <opentelemetry/sdk/trace/simple_processor.h>
-#include <opentelemetry/sdk/trace/tracer_provider.h>
-#include <opentelemetry/trace/provider.h>
-#include <opentelemetry/nostd/unique_ptr.h>
-#include <opentelemetry/exporters/jaeger/jaeger_exporter.h>
-#include <opentelemetry/exporters/ostream/span_exporter.h>
-#include <opentelemetry/sdk/resource/resource.h>
-
-#include <opentelemetry/trace/span.h>
-#include <opentelemetry/trace/tracer.h>
-#include <opentelemetry/trace/context.h>
-#endif
-
 #include "Client.h"
 #include "logger/Logger.h"
 #include "logger/LoggerWrapper.h"

--- a/src/api/qpid-proton/common/ModernClient_tracing_none.cpp
+++ b/src/api/qpid-proton/common/ModernClient_tracing_none.cpp
@@ -1,6 +1,6 @@
 #include "ModernClient.h"
 
-void ModernClient::enableTracing(std::string service_name) const
+void dtests::proton::common::ModernClient::enableTracing(std::string service_name) const
 {
 
     // do nothing

--- a/src/api/qpid-proton/common/ModernClient_tracing_none.cpp
+++ b/src/api/qpid-proton/common/ModernClient_tracing_none.cpp
@@ -1,0 +1,8 @@
+#include "ModernClient.h"
+
+void ModernClient::enableTracing(std::string service_name) const
+{
+
+    // do nothing
+
+}

--- a/src/api/qpid-proton/common/ModernClient_tracing_opentracing.cpp
+++ b/src/api/qpid-proton/common/ModernClient_tracing_opentracing.cpp
@@ -1,0 +1,48 @@
+#include "ModernClient.h"
+
+#include <proton/tracing.hpp>
+
+#include <opentelemetry/sdk/trace/simple_processor.h>
+#include <opentelemetry/sdk/trace/tracer_provider.h>
+#include <opentelemetry/trace/provider.h>
+#include <opentelemetry/nostd/unique_ptr.h>
+#include <opentelemetry/exporters/jaeger/jaeger_exporter.h>
+#include <opentelemetry/exporters/ostream/span_exporter.h>
+#include <opentelemetry/sdk/resource/resource.h>
+
+#include <opentelemetry/trace/span.h>
+#include <opentelemetry/trace/tracer.h>
+#include <opentelemetry/trace/context.h>
+
+void ModernClient::enableTracing(std::string service_name) const
+{
+
+#ifdef __unix__
+    opentelemetry::exporter::jaeger::JaegerExporterOptions opts;
+
+    // Initialize Jaeger Exporter
+    std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> exporter = std::unique_ptr<opentelemetry::sdk::trace::SpanExporter>(
+            new opentelemetry::exporter::jaeger::JaegerExporter(opts));
+
+    // Set service-name
+    auto resource_attributes = opentelemetry::sdk::resource::ResourceAttributes
+            {
+                    {"service.name", service_name}
+            };
+
+    // Creation of the resource for associating it with telemetry
+    auto resource = opentelemetry::sdk::resource::Resource::Create(resource_attributes);
+
+    auto processor = std::unique_ptr<opentelemetry::sdk::trace::SpanProcessor>(
+            new opentelemetry::sdk::trace::SimpleSpanProcessor(std::move(exporter)));
+    auto provider = opentelemetry::nostd::shared_ptr<opentelemetry::trace::TracerProvider>(
+            new opentelemetry::sdk::trace::TracerProvider(std::move(processor), resource));
+
+    // Set the global trace provider
+    opentelemetry::trace::Provider::SetTracerProvider(provider);
+
+    // Enable tracing in proton cpp
+    ::proton::initOpenTelemetryTracer();
+#endif
+
+}

--- a/src/api/qpid-proton/common/ModernClient_tracing_opentracing.cpp
+++ b/src/api/qpid-proton/common/ModernClient_tracing_opentracing.cpp
@@ -14,7 +14,7 @@
 #include <opentelemetry/trace/tracer.h>
 #include <opentelemetry/trace/context.h>
 
-void ModernClient::enableTracing(std::string service_name) const
+void dtests::proton::common::ModernClient::enableTracing(std::string service_name) const
 {
 
     opentelemetry::exporter::jaeger::JaegerExporterOptions opts;

--- a/src/api/qpid-proton/common/ModernClient_tracing_opentracing.cpp
+++ b/src/api/qpid-proton/common/ModernClient_tracing_opentracing.cpp
@@ -17,7 +17,6 @@
 void ModernClient::enableTracing(std::string service_name) const
 {
 
-#ifdef __unix__
     opentelemetry::exporter::jaeger::JaegerExporterOptions opts;
 
     // Initialize Jaeger Exporter
@@ -43,6 +42,5 @@ void ModernClient::enableTracing(std::string service_name) const
 
     // Enable tracing in proton cpp
     ::proton::initOpenTelemetryTracer();
-#endif
 
 }


### PR DESCRIPTION
Compilation fails with older versions of Proton (<0.38.0), because tracing API (function to enable tracing) is not available there.

Implements conditional compilation so that tracing functionality is extracted to a file and file is included only if tracing is supported.