### PR TITLE
don't rely on external trust store in option parser

### DIFF
--- a/src/common/options/modern/ModernOptionsParser.cpp
+++ b/src/common/options/modern/ModernOptionsParser.cpp
@@ -233,13 +233,6 @@ void ModernOptionsParser::validate(const Values &options) const
     }
 
     /* SSL */
-    if ((options.is_set("conn-ssl-verify-peer-name") || options.is_set("con-ssl-verify-peer")) && options.is_set("conn-ssl-trust-store") == false) {
-        print_help();
-        std::stringstream sstm;
-        sstm << "SSL trust store (--conn-ssl-trust-store) must be given";
-        error(sstm.str());
-    }
-
     if (options.is_set("conn-ssl-certificate") && options.is_set("conn-ssl-private-key") == false) {
         print_help();
         std::stringstream sstm;


### PR DESCRIPTION
use system trust store by default (see 9cd680e5)